### PR TITLE
Fix deprecated `scss/at-import-partial-extension`

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ const config = {
 		'scss/at-function-parentheses-space-before': 'never',
 		'scss/at-function-pattern': reLowercase,
 		'scss/at-if-no-null': true,
-		'scss/at-import-partial-extension': 'never',
+		'scss/load-partial-extension': 'never',
 		'scss/at-mixin-argumentless-call-parentheses': 'never',
 		'scss/at-mixin-parentheses-space-before': 'never',
 		'scss/at-mixin-pattern': reLowercase,

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 	"dependencies": {
 		"postcss-scss": "^4.0.9",
 		"stylelint-config-xo": "^1.0.0",
-		"stylelint-scss": "^6.2.1"
+		"stylelint-scss": "^6.4.0"
 	},
 	"devDependencies": {
 		"ava": "^6.1.2",

--- a/test/test.js
+++ b/test/test.js
@@ -12,7 +12,8 @@ const runStylelint = async code => {
 
 	for (const result of results) {
 		if (result.deprecations.length > 0) {
-			throw new Error(`Deprecations:\n${result.deprecations.join('\n')}`);
+			const warnings = result.deprecations.map(x => x.text).join('\n');
+			throw new Error(`Deprecations:\n${warnings}`);
 		}
 
 		if (result.invalidOptionWarnings.length > 0) {


### PR DESCRIPTION
Since `stylelint-scss@6.4.0`, `scss/at-import-partial-extension` has been deprecated.
Here is the warning message:

```
The "scss/at-import-partial-extension" rule is deprecated.
'at-import-partial-extension has been deprecated, and will be removed in '7.0'. Use 'load-partial-extension' instead.
```

See https://github.com/stylelint-scss/stylelint-scss/releases/tag/v6.4.0
